### PR TITLE
feat: [page] 삽입, 출력 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # ABC-DB
+**MEMBER**  
+
+**Lee jingyeong** in @CBNU  
+**Nam jaehong** in @CBNU  
+**Song binwon** in @CBNU  
+**Jang jeonghwan** in @CBNU  
+
+---  
+## overview of our abc-db
+![overall design](https://github.com/user-attachments/assets/65aaa223-d09b-4b49-8c03-a20a68d0be61)

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,23 @@
+FROM alpine
+
+RUN apk update && apk add --no-cache \
+    alpine-sdk \
+    g++ \
+    cmake \
+    make \
+    git \
+    boost-dev \
+    bzip2-dev \
+    zlib-dev
+
+WORKDIR /app
+
+COPY ./src .
+
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.gz && \
+    tar -xzf boost_1_82_0.tar.gz && \
+    cd boost_1_82_0 && \
+    ./bootstrap.sh && \
+    ./b2 install --with-serialization --with-filesystem --prefix=/usr/local
+
+RUN g++ page.cpp -o page -L/usr/local/lib -lboost_serialization -lboost_filesystem -lboost_iostreams -lboost_system

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,19 @@
+#include "page.h"
+
+int main() {
+    Page page(5);  
+
+    const char* record1 = "1231243";
+    const char* record2 = "S123xRecord";
+    page.InsertRecord(record1, std::strlen(record1) + 1); 
+    page.InsertRecord(record2, std::strlen(record2) + 1); 
+
+    page.WriteToFile("page_data.bin"); 
+
+    Page loaded_page(5);               
+    loaded_page.ReadFromFile("page_data.bin"); 
+
+    loaded_page.PrintRecord(); 
+
+    return 0;
+}

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -1,0 +1,103 @@
+
+#include <boost/filesystem.hpp>
+#include <iostream>
+#include <vector>
+#include <cstring> 
+#include <fstream> 
+
+#include "page.h"
+
+void Slot::SetRecordInfo(size_t offset, size_t length) {
+    offset_ = offset;
+    length_ = length;
+};
+
+size_t Slot::GetOffset() const {
+    return offset_;
+};
+
+size_t Slot::GetLength() const {
+    return length_;
+};
+
+bool Slot::IsEmpty() const {
+    return offset_ == 0 && length_ == 0;
+};
+
+bool Slot:: IsDeleted() const {
+    return is_del_;
+};
+
+void Slot:: Clear() {
+    offset_ = 0;
+    length_ = 0;
+    is_del_ = false;
+};
+
+bool Page::HasEnoughSpace(int record_size) const {
+    return slot_offset_ + sizeof(Slot) <= record_offset_ - record_size;
+};
+
+bool Page::InsertRecord(const char* record, int record_size) {
+    if (!HasEnoughSpace(record_size)){
+            std::cerr<< "페이지에 남은 공간이 부족합니다."<<std::endl;
+            return false;
+        }
+
+        record_offset_ -= record_size;
+        std::memcpy(&data_[record_offset_], record, record_size);
+
+
+        Slot new_slot(record_offset_, record_size);
+        std::memcpy(&data_[slot_offset_], &new_slot, sizeof(Slot));
+
+        slot_offset_ += sizeof(Slot);
+        return true;
+};
+
+void Page::WriteToFile(const std::string& filename) const {
+    std::ofstream ofs(filename, std::ios::binary);
+        boost::archive::binary_oarchive oar(ofs);
+        oar << *this;  
+        ofs.close();
+};
+
+void Page::ReadFromFile(const std::string& filename) {
+    boost::filesystem::path file_path(filename);
+       
+       file_path.imbue(std::locale("en_US.UTF-8"));
+
+       if(boost::filesystem::exists(file_path)){
+            std::ifstream ifs;
+            ifs.open(filename.c_str(), std::ios::binary);
+            boost::archive::binary_iarchive iar(ifs);
+            iar >> (*this);
+            ifs.close();
+       }
+}
+
+// 특정 인덱스에서 가변 길이 레코드를 읽는 함수
+std::string Page::ReadRecordFromOffset(int offset, int length) const {
+    if (offset < 0 || offset + length > data_.size()) {
+            throw std::out_of_range("잘못된 오프셋 또는 길이");
+        }
+        return std::string(data_.begin() + offset, data_.begin() + offset + length);
+};
+
+void Page::PrintRecord() const{
+    int current_slot_offset = HEADER_SIZE;
+
+        while (current_slot_offset < slot_offset_) {
+            Slot slot;
+            std::memcpy(&slot, &data_[current_slot_offset], sizeof(Slot));
+
+            // 삭제되지 않은 레코드만 출력
+            if (!slot.IsDeleted()) {
+                std::string record = ReadRecordFromOffset(slot.GetOffset(), slot.GetLength());
+                std::cout << "레코드 데이터: " << record << std::endl;
+            }
+
+            // 다음 슬롯으로 이동
+            current_slot_offset += sizeof(Slot);
+        }
+};

--- a/src/page.h
+++ b/src/page.h
@@ -1,0 +1,76 @@
+#ifndef ABCDB_PAGE_H_
+#define ABCDB_PAGE_H_
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/serialization/utility.hpp>
+#include <boost/serialization/vector.hpp>
+
+class Slot {
+private:
+    size_t offset_;  // 페이지 내의 레코드 시작 위치 (바이트 단위)
+    size_t length_;  // 저장된 레코드의 길이
+    bool is_del_;   // 레코드 삭제여부
+    template<class Archive>
+    void serialize(Archive& ar, const unsigned int version) {
+        ar & offset_;
+        ar & length_;
+        ar & is_del_;
+    }
+public:
+    Slot() : offset_(0), length_(0), is_del_(false) {}
+    Slot(size_t offset, size_t length) : offset_(offset), length_(length), is_del_(false) {}
+    // 레코드가 저장될 위치와 크기를 설정
+    void SetRecordInfo(size_t offset, size_t length);
+    // 레코드의 시작 위치 반환
+    size_t GetOffset() const;
+    // 레코드의 크기 반환
+    size_t GetLength() const;
+    // 슬롯이 비어있는지 여부 확인 (offset이 -1이면 비어있음)
+    bool IsEmpty() const;
+    // 레코드가 삭제 되었는지 여부 확인
+    bool IsDeleted() const ;
+    // 슬롯 비우기
+    void Clear();
+};
+
+class Page {
+private:
+    friend class boost::serialization::access;
+    template<class Archive>
+    void serialize(Archive& ar, const unsigned int version) {
+        ar & page_num_;
+        ar & record_offset_;
+        ar & slot_offset_;
+        ar & data_;
+    }
+    static const int PAGE_SIZE= 4 * 1024;
+    static const int HEADER_SIZE = 128;
+    // 페이지 헤더
+    long age_;
+    bool dirty_;
+    int page_num_;
+    int record_offset_;                  // 데이터가 추가될 위치
+    int slot_offset_;                   // 슬롯이 추가될 위치
+    // 데이터
+    std::vector<char> data_;           // 페이지 데이터 (실제 데이터 저장소)
+
+public:
+    Page(int page_number) :page_num_(page_number), slot_offset_(HEADER_SIZE),record_offset_(PAGE_SIZE) {
+        data_.resize(PAGE_SIZE);
+    }
+    // 충분한 저장공간이 있는지 확인
+    bool HasEnoughSpace(int record_size) const;
+    // 빈 슬롯에 데이터 저장 (페이지 끝에서부터 채워짐)
+    bool InsertRecord(const char* record, int record_size);
+    // 바이너리 파일에 페이지와 슬롯 정보 쓰기
+    void WriteToFile(const std::string& filename) const ;
+    // 바이너리 파일에서 페이지와 슬롯 정보 읽기
+    void ReadFromFile(const std::string& filename);
+    // 특정 인덱스에서 가변 길이 레코드를 읽는 함수
+    std::string ReadRecordFromOffset(int offset, int length) const;
+    // 슬롯의 레코드 데이터 출력
+    void PrintRecord() const ;
+};
+
+#endif


### PR DESCRIPTION
##  feat: [page] 삽입, 출력 

### 슬롯 페이지 구조
![image](https://github.com/user-attachments/assets/4c35bf8c-a662-45ab-82ee-d04dca1d2cba)

- slot에 레코드의 offset과 length를 저장
- slot을 통해 레코드의 정보를 참조


### Page(4096byte)
- Header(128byte)
  -  age_  : LRU 참조변수
  - dirty_  : 수정여부
  - page_num_ : page번호
  - record_offset_: 데이터가 추가될 위치
  - slot_offset_: 슬롯이 추가될 위치
- Data
  - data_: 페이지 데이터 영역

### Slot
- offset_: 페이제 내의 레코드 시작위치
- length_: 저장된 레코드의 기링
- is_del_: 레코드 삭제여부