### PR TITLE
feat: file 구조

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -12,12 +12,12 @@ RUN apk update && apk add --no-cache \
 
 WORKDIR /app
 
-COPY ./src .
-
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.gz && \
     tar -xzf boost_1_82_0.tar.gz && \
     cd boost_1_82_0 && \
     ./bootstrap.sh && \
     ./b2 install --with-serialization --with-filesystem --prefix=/usr/local
 
-RUN g++ page.cpp -o page -L/usr/local/lib -lboost_serialization -lboost_filesystem -lboost_iostreams -lboost_system
+COPY ./src .
+
+RUN g++ main.cpp file.cpp page.cpp -o main -L/usr/local/lib -lboost_serialization -lboost_filesystem -lboost_iostreams -lboost_system

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1,0 +1,117 @@
+#include "file.h"
+
+/*=======================================PageDirectory================================================ */
+PageDirectory::PageDirectory(const size_t offset) : directory_offset_(offset), next_(0), size_(0) {}
+
+bool PageDirectory::HasPage() {
+    return !entries_.empty();
+}
+
+void PageDirectory::IncrementSize() {
+    size_++;
+}
+
+int PageDirectory::GetSize() {
+    return size_;
+}
+
+size_t PageDirectory::GetOffset() const {
+    return directory_offset_;
+}
+
+std::array<PageDirectoryEntry, MAX_ENTRIES_PER_DIR>& PageDirectory::GetEntries() {
+    return entries_;
+}
+
+size_t PageDirectory::GetNext() const {
+    return next_;
+}
+
+void PageDirectory::SetNext(size_t next) {
+    next_ = next;
+}
+
+/*=======================================File================================================ */
+File::File(const std::string& filename) {
+    file_.open(filename, std::ios::in | std::ios::out | std::ios::binary);
+    if (!file_.is_open()) {
+        file_.open(filename, std::ios::out | std::ios::binary);
+        file_.close();
+        file_.open(filename, std::ios::in | std::ios::out | std::ios::binary);
+    }
+}
+
+std::shared_ptr<Page> File::LoadPageFromFile(size_t offset) {
+    file_.seekg(offset);
+    std::shared_ptr<Page> page = std::make_shared<Page>();
+    boost::archive::binary_iarchive iar(file_);
+    iar >> *page;
+    return page;
+}
+
+std::shared_ptr<PageDirectory> File::LoadPageDirFromFile(size_t offset) {
+    file_.seekg(offset);
+    std::shared_ptr<PageDirectory> dir = std::make_shared<PageDirectory>(offset);
+    boost::archive::binary_iarchive iar(file_);
+    iar >> *dir;
+    return dir;
+}
+
+void File::WritePageDirectoryToFile(const PageDirectory& dir) {
+    file_.seekp(dir.GetOffset(), std::ios::beg); // 자신의 위치에 덮어쓴다.
+    boost::archive::binary_oarchive oar(file_);
+    oar << dir;
+}
+
+size_t File::WritePageToFile(PageDirectory& dir, const Page& page) {
+    if (page.GetPageIdx() == -1) {  // 직렬화 안된 Page인 경우
+        file_.seekp(0, std::ios::end);  // File 제일 뒤를 point
+    } else {
+        std::array<PageDirectoryEntry, MAX_ENTRIES_PER_DIR>& entries = dir.GetEntries();
+        file_.seekp(entries[page.GetPageIdx()].offset, std::ios::beg);  // Page의 위치를 point
+    }
+    size_t offset = file_.tellp();
+    boost::archive::binary_oarchive oar(file_);
+    oar << page;
+    return offset;
+}
+
+void File::AddPageToDirectory(PageDirectory& dir, Page& page) {
+    size_t page_offset = WritePageToFile(dir, page);
+    
+    if (dir.GetSize() >= MAX_ENTRIES_PER_DIR) { // PageDirectory가 가득찬경우
+        file_.seekp(0, std::ios::end);  // File의 제일 뒤를 point
+        size_t offset = file_.tellp();
+        PageDirectory new_dir(offset);  // 새로운 PageDirectory create
+        WritePageDirectoryToFile(new_dir);
+        dir.SetNext(offset);    // 새로운 PageDirectory를 next로 기록
+        WritePageDirectoryToFile(dir);  // 현재 PageDirectory Write
+        dir = new_dir;
+    }
+
+    std::array<PageDirectoryEntry, MAX_ENTRIES_PER_DIR>& entries = dir.GetEntries();
+    entries[dir.GetSize()] = {page_offset, false};  // 새로운 Page 관리
+    page.SetPageIdx(dir.GetSize()); // Page는 entries에서의 본인 index저장
+    dir.IncrementSize();
+}
+
+std::shared_ptr<Page> File::GetPage(PageDirectory& dir, int page_index) {
+    std::array<PageDirectoryEntry, MAX_ENTRIES_PER_DIR>& entries = dir.GetEntries();
+    if (page_index >= dir.GetSize()) {
+        throw std::out_of_range("잘못된 페이지 인덱스입니다.");
+    }
+    PageDirectoryEntry& entry = entries[page_index];
+    std::shared_ptr<Page> page = LoadPageFromFile(entry.offset);
+    entry.is_loaded = true;
+    return page;
+}
+
+std::shared_ptr<PageDirectory> File::GetPageDir(size_t offset) {
+    return LoadPageDirFromFile(offset);
+}
+
+File::~File() {
+    if (file_.is_open()) {
+        file_.close();
+    }
+}

--- a/src/file.h
+++ b/src/file.h
@@ -1,0 +1,167 @@
+#ifndef ABCDB_FILE_H_
+#define ABCDB_FILE_H_
+
+#include <cstring> 
+#include <fstream> 
+#include <array>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/serialization/utility.hpp>
+#include <boost/serialization/array.hpp>
+#include "page.h"
+
+/**
+ * @brief 페이지 디렉토리 entries에 들어가는 페이지를 참조하기위한 정보
+ * 
+ */
+struct PageDirectoryEntry{
+    size_t offset;  // 파일 내 페이지의 오프셋
+    bool is_loaded = false; // 페이지가 메모리에 로드되어 있는지 여부
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int version){
+        ar & offset;
+        ar & is_loaded;
+    }
+};
+
+const int DIRECTORY_BODY_SIZE = PAGE_SIZE - sizeof(size_t) * 2 - sizeof(int);   // 페이지 디렉토리의 헤더를 제외한 사이즈
+constexpr int MAX_ENTRIES_PER_DIR = DIRECTORY_BODY_SIZE / sizeof(PageDirectoryEntry);   // 최대 페이지 entry 저장 개수
+
+/**
+ * @brief 파일내 페이지의 offset을 entry로 관리
+ * 
+ */
+class PageDirectory {
+private:
+    size_t directory_offset_;   // 페이지 디렉토리 offset
+    size_t next_;   // 다음 페이지 디렉토리 offset
+    int size_;  // 현재 entries 사이즈
+    std::array<PageDirectoryEntry, MAX_ENTRIES_PER_DIR> entries_;   // page offset을 저장하는 array
+
+public:
+    PageDirectory(const size_t offset);
+    
+    template<class Archive>
+     void serialize(Archive& ar, const unsigned int version) {
+        ar & next_;
+        ar & directory_offset_;
+        ar & size_;
+        ar & boost::serialization::make_array(entries_.data(), entries_.size());
+    }
+
+    /**
+     * @brief 페이지 디렉토리가 페이지를 하나라도 가지고 있는지 여부
+     * 
+     * @return true 하나 이상의 페이지 가지고 있음.
+     * @return false 페이지 가지고 있지 않음.
+     */
+    bool HasPage();
+
+    /**
+     * @brief entries의 사이즈 증가
+     * 
+     */
+    void IncrementSize();
+
+    /**
+     * @brief Get the Size object
+     * 
+     * @return int entries_ size
+     */
+    int GetSize();
+
+    /**
+     * @brief Get the Offset object
+     * 
+     * @return size_t 페이지 디렉토리 offset
+     */
+    size_t GetOffset() const;
+
+    /**
+     * @brief Get the Entries object
+     * 
+     * @return std::array<PageDirectoryEntry, MAX_ENTRIES_PER_DIR>& 
+     */
+    std::array<PageDirectoryEntry, MAX_ENTRIES_PER_DIR>& GetEntries();
+    
+    /**
+     * @brief Get the Next object
+     * 
+     * @return size_t  다음 페이지 디렉토리 offset
+     */
+    size_t GetNext() const;
+
+    /**
+     * @brief Set the Next object
+     * 
+     * @param next 다음 페이지 디렉토리 offset
+     */
+    void SetNext(size_t next);
+};
+
+/**
+ * @brief PageDirectory 및 Page를 관리
+ * 
+ */
+class File {
+private:
+    std::fstream file_;
+
+    /**
+     * @brief 파일에서 페이지 읽어옴
+     * 
+     * @param offset 읽어올 Page의 offset
+     * @return std::shared_ptr<Page>  Page의 스마트 포인터(참조 카운팅을 통해 마지막 참조가 해제되면 자동으로 객체 삭제)
+     */
+    std::shared_ptr<Page> LoadPageFromFile(size_t offset);
+    /**
+     * @brief 파일에서 페이지 디렉토리 읽어옴
+     * 
+     * @param offset PageDirectory의 offset
+     * @return std::shared_ptr<PageDirectory> PageDirectory의 스마트 포인터(참조 카운팅을 통해 마지막 참조가 해제되면 자동으로 객체 삭제)
+     */
+    std::shared_ptr<PageDirectory> LoadPageDirFromFile(size_t offset);
+
+public:
+    File(const std::string& filename);
+    /**
+     * @brief 페이지 디렉토리 파일에 쓰기
+     * 
+     * @param dir File에 직렬화 시킬 PageDirectory
+     */
+    void WritePageDirectoryToFile(const PageDirectory& dir);
+    /**
+     * @brief 페이지 파일에 쓰기
+     * 
+     * @param dir Page를 관리하는 PageDirectory
+     * @param page File에 직렬화 시킬 Page
+     * @return size_t File에 작성된 Page의 offset
+     */
+    size_t WritePageToFile(PageDirectory& dir, const Page& page);
+    /**
+     * @brief 페이지 페이지 디렉토리에 추가
+     * 
+     * @param dir Page를 관리할 PageDirectory
+     * @param page PageDirectory에 새롭게 추가할 Page
+     */
+    void AddPageToDirectory(PageDirectory& dir, Page& page);
+    /**
+     * @brief Get the Page object
+     * 
+     * @param dir 
+     * @param page_index 
+     * @return std::shared_ptr<Page> 
+     */
+    std::shared_ptr<Page> GetPage(PageDirectory& dir, int page_index);
+    /**
+     * @brief Get the Page Dir object
+     * 
+     * @param offset 
+     * @return std::shared_ptr<PageDirectory> 
+     */
+    std::shared_ptr<PageDirectory> GetPageDir(size_t offset = 0);
+    //
+    ~File();
+};
+
+#endif  // ABCDB_FILE_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,19 +1,58 @@
 #include "page.h"
+#include "file.h"
+#include <iostream>
+
+
+void search(File& f);
+void iter(File& f, PageDirectory& dir);
 
 int main() {
-    Page page(5);  
+    std::shared_ptr<Page> p;
 
-    const char* record1 = "1231243";
-    const char* record2 = "S123xRecord";
-    page.InsertRecord(record1, std::strlen(record1) + 1); 
-    page.InsertRecord(record2, std::strlen(record2) + 1); 
+    /**
+     * @brief 
+     *  TODO::table생성 시 파일 및 첫번재 페이지 디렉토리 자동 생성.
+     *   지금은 처음 실행 시 
+     *   아래 주석 해제 후 실행
+     *   주석 후 빌드
+     *   다시 실행
+     */
+    File f("student.bin");
+    // PageDirectory directory(0);
+    // f.WritePageDirectoryToFile(directory);
+    
+    std::shared_ptr<PageDirectory> dir = f.GetPageDir(); 
 
-    page.WriteToFile("page_data.bin"); 
+    p = std::make_shared<Page>();
+    f.AddPageToDirectory(*dir,*p);
+  
+    //레코드 삽입 및 직렬화
+    const char* record1 = "jjang";
+    const char* record2 = "1458%%$";
+    p.get()->InsertRecord(record1, std::strlen(record1) + 1);
+    p.get()->InsertRecord(record2, std::strlen(record2) + 1);
+    f.WritePageToFile(*dir,*p);
+    f.WritePageDirectoryToFile(*dir);
 
-    Page loaded_page(5);               
-    loaded_page.ReadFromFile("page_data.bin"); 
-
-    loaded_page.PrintRecord(); 
-
+    //페이지디렉토리가 가리키는 페이지의 레코드 전부출력
+    search(f);
     return 0;
+}
+
+void search(File& f){
+    std::shared_ptr<PageDirectory> dir = f.GetPageDir(); 
+    while(dir->GetNext()){
+        iter(f, *dir);
+        size_t offset = dir->GetNext();
+        dir = f.GetPageDir(offset);
+    }
+    iter(f, *dir);
+}
+void iter(File& f, PageDirectory& dir){
+    const auto& entries = dir.GetEntries();
+    for(int i=0; i<dir.GetSize(); i++){
+        std::cout<<"page인덱스: "<<i<<std::endl;
+        std::shared_ptr<Page> p2 = f.GetPage(dir,i);
+        p2->PrintRecord();
+    }
 }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -1,12 +1,12 @@
 
 #include <boost/filesystem.hpp>
 #include <iostream>
-#include <vector>
 #include <cstring> 
 #include <fstream> 
 
 #include "page.h"
 
+/*=======================================Slot================================================ */
 void Slot::SetRecordInfo(size_t offset, size_t length) {
     offset_ = offset;
     length_ = length;
@@ -34,6 +34,7 @@ void Slot:: Clear() {
     is_del_ = false;
 };
 
+/*=======================================Page================================================ */
 bool Page::HasEnoughSpace(int record_size) const {
     return slot_offset_ + sizeof(Slot) <= record_offset_ - record_size;
 };
@@ -55,27 +56,6 @@ bool Page::InsertRecord(const char* record, int record_size) {
         return true;
 };
 
-void Page::WriteToFile(const std::string& filename) const {
-    std::ofstream ofs(filename, std::ios::binary);
-        boost::archive::binary_oarchive oar(ofs);
-        oar << *this;  
-        ofs.close();
-};
-
-void Page::ReadFromFile(const std::string& filename) {
-    boost::filesystem::path file_path(filename);
-       
-       file_path.imbue(std::locale("en_US.UTF-8"));
-
-       if(boost::filesystem::exists(file_path)){
-            std::ifstream ifs;
-            ifs.open(filename.c_str(), std::ios::binary);
-            boost::archive::binary_iarchive iar(ifs);
-            iar >> (*this);
-            ifs.close();
-       }
-}
-
 // 특정 인덱스에서 가변 길이 레코드를 읽는 함수
 std::string Page::ReadRecordFromOffset(int offset, int length) const {
     if (offset < 0 || offset + length > data_.size()) {
@@ -83,6 +63,14 @@ std::string Page::ReadRecordFromOffset(int offset, int length) const {
         }
         return std::string(data_.begin() + offset, data_.begin() + offset + length);
 };
+
+int Page::GetPageIdx() const{
+    return page_idx_;
+}
+
+void Page::SetPageIdx(const int index){
+    page_idx_=index;
+}
 
 void Page::PrintRecord() const{
     int current_slot_offset = HEADER_SIZE;

--- a/src/page.h
+++ b/src/page.h
@@ -6,71 +6,138 @@
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/vector.hpp>
 
+constexpr int PAGE_SIZE= 4 * 1024;
+
+/**
+ * @brief Page내부에서 Record를 관리하는 Slot
+ * 
+ */
 class Slot {
-private:
-    size_t offset_;  // 페이지 내의 레코드 시작 위치 (바이트 단위)
-    size_t length_;  // 저장된 레코드의 길이
-    bool is_del_;   // 레코드 삭제여부
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int version) {
-        ar & offset_;
-        ar & length_;
-        ar & is_del_;
-    }
-public:
-    Slot() : offset_(0), length_(0), is_del_(false) {}
-    Slot(size_t offset, size_t length) : offset_(offset), length_(length), is_del_(false) {}
-    // 레코드가 저장될 위치와 크기를 설정
-    void SetRecordInfo(size_t offset, size_t length);
-    // 레코드의 시작 위치 반환
-    size_t GetOffset() const;
-    // 레코드의 크기 반환
-    size_t GetLength() const;
-    // 슬롯이 비어있는지 여부 확인 (offset이 -1이면 비어있음)
-    bool IsEmpty() const;
-    // 레코드가 삭제 되었는지 여부 확인
-    bool IsDeleted() const ;
-    // 슬롯 비우기
-    void Clear();
+    private:
+        size_t offset_;  // 페이지 내의 레코드 시작 위치 (바이트 단위)
+        size_t length_;  // 저장된 레코드의 길이
+        bool is_del_;   // 레코드 삭제여부
+        template<class Archive>
+        void serialize(Archive& ar, const unsigned int version) {
+            ar & offset_;
+            ar & length_;
+            ar & is_del_;
+        }
+    public:
+        Slot() : offset_(0), length_(0), is_del_(false) {}
+        Slot(size_t offset, size_t length) : offset_(offset), length_(length), is_del_(false) {}
+        /**
+         * @brief Set the Record Info object
+         * 
+         * @param offset Record 시작위치
+         * @param length Record 크기
+         */
+        void SetRecordInfo(size_t offset, size_t length);
+        /**
+         * @brief Get the Offset object
+         * 
+         * @return size_t Record offset
+         */
+        size_t GetOffset() const;
+        /**
+         * @brief Get the Length object
+         * 
+         * @return size_t Record 크기
+         */
+        size_t GetLength() const;
+        /**
+         * @brief 슬롯이 비어있는지 여부 확인
+         * 
+         * @return true empty
+         * @return false 
+         */
+        bool IsEmpty() const;
+        /**
+         * @brief 레코드가 삭제 되었는지 여부 확인
+         * 
+         * @return true Record 삭제됨
+         * @return false 
+         */
+        bool IsDeleted() const ;
+        void Clear();
 };
 
+/**
+ * @brief 실질적인 Record를 관리하는 Page
+ * 
+ */
 class Page {
-private:
-    friend class boost::serialization::access;
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int version) {
-        ar & page_num_;
-        ar & record_offset_;
-        ar & slot_offset_;
-        ar & data_;
-    }
-    static const int PAGE_SIZE= 4 * 1024;
-    static const int HEADER_SIZE = 128;
-    // 페이지 헤더
-    long age_;
-    bool dirty_;
-    int page_num_;
-    int record_offset_;                  // 데이터가 추가될 위치
-    int slot_offset_;                   // 슬롯이 추가될 위치
-    // 데이터
-    std::vector<char> data_;           // 페이지 데이터 (실제 데이터 저장소)
+    private:
+        friend class boost::serialization::access;
+        template<class Archive>
+        void serialize(Archive& ar, const unsigned int version) {
+            ar & page_idx_;
+            ar & record_offset_;
+            ar & slot_offset_;
+            ar & data_;
+        }
+        static const int HEADER_SIZE = 128;
+        
+        // 페이지 헤더
+        long age_;
+        bool dirty_;
+        int page_idx_;                     // 페이지 디렉터리내의 index  
+        int record_offset_;                  // 데이터가 추가될 위치
+        int slot_offset_;                   // 슬롯이 추가될 위치
+        // 데이터
+        std::vector<char> data_;           // 페이지 데이터 (실제 데이터 저장소)
 
-public:
-    Page(int page_number) :page_num_(page_number), slot_offset_(HEADER_SIZE),record_offset_(PAGE_SIZE) {
-        data_.resize(PAGE_SIZE);
-    }
-    // 충분한 저장공간이 있는지 확인
-    bool HasEnoughSpace(int record_size) const;
-    // 빈 슬롯에 데이터 저장 (페이지 끝에서부터 채워짐)
-    bool InsertRecord(const char* record, int record_size);
-    // 바이너리 파일에 페이지와 슬롯 정보 쓰기
-    void WriteToFile(const std::string& filename) const ;
-    // 바이너리 파일에서 페이지와 슬롯 정보 읽기
-    void ReadFromFile(const std::string& filename);
-    // 특정 인덱스에서 가변 길이 레코드를 읽는 함수
-    std::string ReadRecordFromOffset(int offset, int length) const;
-    // 슬롯의 레코드 데이터 출력
-    void PrintRecord() const ;
+    public:
+        Page() :page_idx_(-1), slot_offset_(HEADER_SIZE),record_offset_(PAGE_SIZE) {
+            data_.resize(PAGE_SIZE);
+        }
+        /**
+         * @brief 충분한 저장공간이 있는지 확인
+         * 
+         * @param record_size 새롭게 저장할 Record의 크기
+         * @return true 현재 페이지에 저장 가능
+         * @return false 현재 페이지에 저장 불가능 
+         */
+        bool HasEnoughSpace(int record_size) const;
+
+        /**
+         * @brief 빈 슬롯에 데이터 저장 (페이지 끝에서부터 채워짐)
+         * 
+         * @param record 새롭게 저장할 Record
+         * @param record_size 새롭게 저장할 Record의 크기
+         * @return true 성공
+         * @return false 실패
+         */
+        bool InsertRecord(const char* record, int record_size);
+
+        /**
+         * @brief 특정 인덱스에서 가변 길이 레코드를 읽는 함수
+         * 
+         * @param offset 읽어올 Record의 offset
+         * @param length 읽어올 Record의 크기
+         * @return std::string Record
+         */
+        std::string ReadRecordFromOffset(int offset, int length) const;
+
+        /**
+         * @brief Get the Page Idx object
+         * 
+         * @return int Page의 인덱스 
+         */
+        int GetPageIdx() const;
+
+        /**
+         * @brief Set the Page Idx object
+         * 
+         * @param index Page의 인덱스 
+         */
+        void SetPageIdx(const int index);
+        
+        /**
+         * @brief 슬롯의 레코드 데이터 출력
+         * 
+         */
+        void PrintRecord() const ;
 };
 
 #endif


### PR DESCRIPTION
## 개요
- File내부에 PageDirectory와 Page가 저장됨
- PageDirectory는 Page와 마찬가지로 4KB
- PageDirectory가 4KB를 넘을경우 새로운 PageDirectory를 생성후 next로 기록
- PageDirectory는 entries로 Page의 offset을 관리

## 예시
- Record를 출력하고자하는 경우
1. File을 파일명으로 참조
2. PageDirectory를 불러온다.
3. PageDirectory가 기록하고 있는 Page를 불러온다.
4. Page의 Slot을 통해서 Record를 출력

- File을 열어 새롭게 Page와 PageDirectory를 기록하는 경우

```
    File f("student.bin");
    // PageDirectory directory(0);
    // f.WritePageDirectoryToFile(directory);
    
    std::shared_ptr<PageDirectory> dir = f.GetPageDir(); 

    p = std::make_shared<Page>();
    f.AddPageToDirectory(*dir,*p);
  
    //레코드 삽입 및 직렬화
    const char* record1 = "jjang";
    const char* record2 = "1458%%$";
    p.get()->InsertRecord(record1, std::strlen(record1) + 1);
    p.get()->InsertRecord(record2, std::strlen(record2) + 1);
    f.WritePageToFile(*dir,*p);
    f.WritePageDirectoryToFile(*dir);
```
바로 위의 예시에서 PageDirectory를 생성하는 주석친 부분은
Table을 생성할때 File과 첫번째 PageDirectory를 자동으로 생성할 예정이라서 예시로만 나타내었다.