### PR TITLE
fix: Page 패딩 최적화 & Page 멤버 초기화 수정

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1,5 +1,5 @@
 #include "file.h"
-
+#include <iostream>
 /*=======================================PageDirectory================================================ */
 PageDirectory::PageDirectory(const size_t offset) : directory_offset_(offset), next_(0), size_(0) {}
 
@@ -61,6 +61,7 @@ void File::WritePageDirectoryToFile(const PageDirectory& dir) {
     file_.seekp(dir.GetOffset(), std::ios::beg); // 자신의 위치에 덮어쓴다.
     boost::archive::binary_oarchive oar(file_);
     oar << dir;
+    file_.flush();
 }
 
 size_t File::WritePageToFile(PageDirectory& dir, const Page& page) {
@@ -78,8 +79,8 @@ size_t File::WritePageToFile(PageDirectory& dir, const Page& page) {
 
 void File::AddPageToDirectory(PageDirectory& dir, Page& page) {
     size_t page_offset = WritePageToFile(dir, page);
-    
     if (dir.GetSize() >= MAX_ENTRIES_PER_DIR) { // PageDirectory가 가득찬경우
+        std::cout<<"called AddPageToDirectory"<<std::endl;
         file_.seekp(0, std::ios::end);  // File의 제일 뒤를 point
         size_t offset = file_.tellp();
         PageDirectory new_dir(offset);  // 새로운 PageDirectory create

--- a/src/file.h
+++ b/src/file.h
@@ -43,8 +43,8 @@ public:
     
     template<class Archive>
      void serialize(Archive& ar, const unsigned int version) {
-        ar & next_;
         ar & directory_offset_;
+        ar & next_;
         ar & size_;
         ar & boost::serialization::make_array(entries_.data(), entries_.size());
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,16 +23,27 @@ int main() {
     
     std::shared_ptr<PageDirectory> dir = f.GetPageDir(); 
 
-    p = std::make_shared<Page>();
-    f.AddPageToDirectory(*dir,*p);
+    std::ofstream outfile("output.txt");  // 파일 열기
+    if (outfile.is_open()){
+        for (int i=0;i<800;i++){
+            p = std::make_shared<Page>();
+            f.AddPageToDirectory(*dir,*p);
+            //레코드 삽입 및 직렬화
+            const char* record1 = "jjang";
+            const char* record2 = "1458%%$";
+            p.get()->InsertRecord(record1, std::strlen(record1) + 1);
+            p.get()->InsertRecord(record2, std::strlen(record2) + 1);
+            f.WritePageToFile(*dir,*p);
+            f.WritePageDirectoryToFile(*dir);
+            outfile<<"page: "<<i<<std::endl;
+        }
+    }
+
+    outfile.close();
+    
+   
   
-    //레코드 삽입 및 직렬화
-    const char* record1 = "jjang";
-    const char* record2 = "1458%%$";
-    p.get()->InsertRecord(record1, std::strlen(record1) + 1);
-    p.get()->InsertRecord(record2, std::strlen(record2) + 1);
-    f.WritePageToFile(*dir,*p);
-    f.WritePageDirectoryToFile(*dir);
+    
 
     //페이지디렉토리가 가리키는 페이지의 레코드 전부출력
     search(f);
@@ -51,8 +62,8 @@ void search(File& f){
 void iter(File& f, PageDirectory& dir){
     const auto& entries = dir.GetEntries();
     for(int i=0; i<dir.GetSize(); i++){
-        std::cout<<"page인덱스: "<<i<<std::endl;
+        //std::cout<<"page인덱스: "<<i<<std::endl;
         std::shared_ptr<Page> p2 = f.GetPage(dir,i);
-        p2->PrintRecord();
+        //p2->PrintRecord();
     }
 }

--- a/src/page.h
+++ b/src/page.h
@@ -75,30 +75,30 @@ class Page {
         friend class boost::serialization::access;
         template<class Archive>
         void serialize(Archive& ar, const unsigned int version) {
-            ar & page_idx_;
             ar & age_;
-            ar & dirty_;
-            ar & pinned_;
+            ar & page_idx_;
             ar & record_offset_;
             ar & slot_offset_;
+            ar & dirty_;
+            ar & pinned_;
             ar & data_;
         }
         static const int HEADER_SIZE = 128;
         
         // 페이지 헤더
         long age_;          
-        bool dirty_;                  // 페이지 변경 여부   
-        bool pinned_;                        // 페이지 고정 여부
         int page_idx_;                     // 페이지 디렉터리내의 index  
         int record_offset_;                  // 데이터가 추가될 위치
         int slot_offset_;                   // 슬롯이 추가될 위치
+        bool dirty_;                  // 페이지 변경 여부   
+        bool pinned_;                        // 페이지 고정 여부
         Page *next_;                        // 다음 페이지
         Page *prev_;                        // 이전 페이지
         // 데이터
         std::vector<char> data_;           // 페이지 데이터 (실제 데이터 저장소)
 
     public:
-        Page() :page_idx_(-1), slot_offset_(HEADER_SIZE),record_offset_(PAGE_SIZE) {
+        Page() :page_idx_(-1), slot_offset_(HEADER_SIZE),record_offset_(PAGE_SIZE), dirty_(false), pinned_(false) {
             data_.resize(PAGE_SIZE);
         }
 


### PR DESCRIPTION
## Fix/page

- 페이지 패딩 최적화 

```
  // 페이지 헤더
        long age_;          
        bool dirty_;                  // 페이지 변경 여부   
        bool pinned_;                        // 페이지 고정 여부
        int page_idx_;                     // 페이지 디렉터리내의 index  
        int record_offset_;                  // 데이터가 추가될 위치
        int slot_offset_;                   // 슬롯이 추가될 위치
        Page *next_;                        // 다음 페이지
        Page *prev_;                        // 이전 페이지
        // 데이터
        std::vector<char> data_;           // 페이지 데이터 (실제 데이터 저장소)
```

- 페이지 생성 시 멤버 초기화 수정
```
Page() :page_idx_(-1), slot_offset_(HEADER_SIZE),record_offset_(PAGE_SIZE) {
            data_.resize(PAGE_SIZE);
        }
```