### PR TITLE
fix : flush disk & lru replacement

### DIFF
--- a/src/bufferManager.h
+++ b/src/bufferManager.h
@@ -14,7 +14,7 @@ class BufferManager
     private:
         // PageHandler *pageHandler;
         BufferPool *bufferPool;
-        File *file;
+        std::string file_;
     public:
         BufferManager()
             :bufferPool(new BufferPool())
@@ -31,7 +31,7 @@ class BufferManager
          * @brief 페이지가 버퍼 풀에 다 찼을 때 last Page evicton 실시
          */
         void ReplacePage(Page *page);
-        void SetFile(File *file){this->file=file;std::cout<<"[SetFile] "<<std::endl;}
+        void SetFile(std::string fileName){file_=fileName;}
         void DebugAllBufferPool();
         void DebugTableBufferPool(std::string fileName);
         void DebugTableBufferPool(std::string fileName,int pageIdx);

--- a/src/bufferPool.cpp
+++ b/src/bufferPool.cpp
@@ -8,28 +8,58 @@ void BufferPool::InsertPage(std::shared_ptr<Page> page)
         return;
     }
 
-    if (infreq.size() < MAX_INFREQ_SIZE)
+    if (infreq.size() < MAX_INFREQ_SIZE) //infreq에 먼저 삽입 시도
     {
         std::cout<<"[Insert Page] Insert Page to infreq"<<std::endl;
         infreq.push_back(page);
     }
-    else if (freq.size() < MAX_FREQ_SIZE)
+    else if (freq.size() < MAX_FREQ_SIZE) // infreq가 다 찼으면 freq로 삽입
     {
         std::cout<<"[Insert Page] Insert Page to freq"<<std::endl;
         freq.push_front(page);
     }
-    else
+    else // LRU 알고리즘 적용해서 inreq에서 tail에서 빼고 infreq 두 번째에 삽입 (첫 번째에는 infreqHead가 있음)
     {
-        std::cerr << "Error: Buffer pool is full." << std::endl;
+        infreq.pop_back();
+        auto it = infreq.begin();
+        if (it != infreq.end()) {
+            ++it; // 두 번째 위치로 이동
+        }
+        infreq.insert(it, page);
     }
     
 }
+
+void BufferPool::PromotePage(std::shared_ptr<Page> page)
+{
+    if (!page)
+    {
+        std::cerr << "Error: Attempted to promote a null page." << std::endl;
+        return;
+    }
+
+    if (infreq.size() < MAX_INFREQ_SIZE)
+    {
+        std::cerr << "Error: Attempted to promote a page in infreq." << std::endl;
+        return;
+    }
+
+    if (freq.size() >= MAX_FREQ_SIZE)
+    {
+        std::cerr << "Error: Attempted to promote a page in freq when freq is full." << std::endl;
+        return;
+    }
+
+    infreq.remove(page);
+    freq.push_front(page);
+}
+
 
 void BufferPool::DebugBufferPool()
 {
     std::cout << "[Debug Buffer Pool]" << std::endl;
     TraverseBufferPoolVoid([](const std::shared_ptr<Page> &page) -> void {
-        std::cout << "page index : " << page->GetPageIdx() << "\tfilename : "<<page->GetFilename()<<std::endl;
+        std::cout << "page index : " << page->GetPageIdx() << "\tfilename : "<<page->GetFilename()<<page->GetData()<<std::endl;
     });
 }
 

--- a/src/bufferPool.h
+++ b/src/bufferPool.h
@@ -43,6 +43,8 @@ public:
      * @brief 버퍼 풀에 페이지를 삽입. infreq부터 삽입하고 다차면 freq로 넘어감
      */
     void InsertPage(std::shared_ptr<Page> page);
+    void PromotePage(std::shared_ptr<Page> page);
+    void ReplacePage(std::shared_ptr<Page> page);
     
 
     /**
@@ -55,6 +57,7 @@ public:
      */
     void TraverseBufferPoolVoid(std::function<void(const std::shared_ptr<Page>&)> callback);
     void DebugBufferPool();
+
     std::list<std::shared_ptr<Page>> GetFreq() { return freq; }
     std::list<std::shared_ptr<Page>> GetInfreq() { return infreq; }
 

--- a/src/disk_manager.cpp
+++ b/src/disk_manager.cpp
@@ -61,7 +61,6 @@ void DiskManager::Insert(SQLInsert &st){
             file.WritePageToFile(*dir,*page);
         }
         file.WritePageDirToFile(*dir);
-        // std::cout<<"[insert dir.size]"<<dir->GetSize()<<std::endl;
         cm_->WriteArchiveFile();
     }
     // 버퍼에 삽입
@@ -71,6 +70,7 @@ void DiskManager::Insert(SQLInsert &st){
         bPage->SetFilename(tbl->GetFile());
         bm_->WriteBlock(bPage,content,content_len);
     }
+    bm_->DebugAllBufferPool();
 }
 
 void DiskManager::Select(SQLSelect &st){ //select all
@@ -84,11 +84,11 @@ void DiskManager::Select(SQLSelect &st){ //select all
     File file(tbl->GetFile());
     std::shared_ptr<PageDirectory> dir = file.GetPageDir(0);
     std::vector<std::vector<TKey> > tkey_values;
-    bm_->SetFile(&file);
+    bm_->SetFile(st.tb_name());
     do{
         for(int i=0;i<dir->GetSize();i++)
         {
-            std::cout<<"size::"<<dir->GetSize()<<std::endl;
+
             std::shared_ptr<Page> page;
             page=bm_->GetPageFromBufferPool(tbl->GetFile(),i);
             if(!page)
@@ -111,6 +111,7 @@ void DiskManager::Select(SQLSelect &st){ //select all
         std::cout<<std::endl;
     }
     std::cout << std::endl;
+    bm_->DebugAllBufferPool();
 }
 
 std::vector<TKey> DiskManager::ParseRecord(Table *tbl, std::vector<char> &data, int offset){


### PR DESCRIPTION
## DBMS 종료 시 디스크로 flush
void Interpreter::Run()
    case 10: {
      api->Quit();
      exit(0);
    } break;
    
Quit 함수 실행시 bufferManager의 소멸자 호출
소멸자 호출 시 디스크로 플러시
버퍼 순회하면서 dirty인 페이지 찾아서 디스크로 내려쓰기

## LRU algo
### Promote Page
    infreq.remove(page);
    freq.push_front(page);
    자주 사용되지 않는 페이지 리스트에서 자주 사용하는 페이지의 맨앞으로 이동
### Replace
    BufferManager::InsertPage()
     버퍼풀이 가득차 있다면 infreq리스트에서 제거 후 infreq의 2번째에 삽입 1번째는 Head가 존재